### PR TITLE
Fix wrong import path in callFunctions

### DIFF
--- a/app/lib/callFunctions.ts
+++ b/app/lib/callFunctions.ts
@@ -1,4 +1,4 @@
-import { updateOrderTool, processPaymentTool, paymentInputTool, completePaymentTool } from './utils/clientTools';
+import { updateOrderTool, processPaymentTool, paymentInputTool, completePaymentTool } from './clientTools';
 
 // Extender el tipo Window global para incluir las propiedades personalizadas
 declare global {


### PR DESCRIPTION
## Summary

- fix invalid relative import path in `app/lib/callFunctions.ts`

## Testing

- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*